### PR TITLE
Fix `regolith-displayd` startup failure due to absent kanshi config 

### DIFF
--- a/data/regolith-init-displayd.service
+++ b/data/regolith-init-displayd.service
@@ -7,13 +7,16 @@ After=gnome-session.target
 Requires=regolith-init-kanshi.service
 Before=regolith-init-kanshi.service
 
+StartLimitIntervalSec=30
+StartLimitBurst=5
+
 [Service]
 Type=dbus
 BusName=org.gnome.Mutter.DisplayConfig
+ExecStartPre=/usr/bin/regolith-displayd-init
 ExecStart=/usr/bin/regolith-displayd
 Restart=on-failure
-StartLimitIntervalSec=10
-StartLimitBurst=5
+RestartSec=5
 
 
 [Install]

--- a/regolith-displayd-init
+++ b/regolith-displayd-init
@@ -23,5 +23,3 @@ if [ "$PROFILES_COUNT" == "0" ]; then
 else
 	echo "FOUND $PROFILES_COUNT profiles" 
 fi
-
-/usr/bin/regolith-displayd


### PR DESCRIPTION
`regolith-displayd-init` initially set up the base configurations for `kanshi`. However, the systemd service (`regolith-init-displayd.service`) directly starts `regolith-displayd`. This causes a failure for `regolith-init-kanshi.service` (due to absent configs). 

This PR ensures that `regolith-displayed-init` is started before `regolith-displayed`. It also adjusts auto restart condition to prevent repeated starts in short bursts. The startup of `regolith-displayd` is no longer the responsibility of `regolith-displayd-init`.

